### PR TITLE
Fix issue with raw param for get if a new registry is new or not

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.idea/

--- a/index.js
+++ b/index.js
@@ -35,16 +35,15 @@ module.exports = function(query, doc, options, callback) {
             setDefaultsOnInsert: true
         }, options);
 
-        options.passRawResult = true;
+        options.rawResult = true;
         options.upsert = true;
 
         // Execute the atomic query
-        self.findOneAndUpdate(query, doc, options, (err, record, raw) => {
+        self.findOneAndUpdate(query, doc, options, (err, record) => {
             if (err) return next(err);
-
             next(null, {
-                doc: record,
-                isNew: !raw.lastErrorObject.updatedExisting
+                doc: record.value,
+                isNew: !record.lastErrorObject.updatedExisting
             });
         });
     };


### PR DESCRIPTION
Fix issue with raw param for get if a new registry is or not inserted or only found. Delete raw param because now it is not necessary and get 'isNew' throw record.lastErrorObject.updatedExisting

Your solution is great!, because I needed this atomic function and get if the registry was finally created or only found, but I got an error. The param raw it was undefined. Well, now is fixed.

Thank you for your solution, you helped me.